### PR TITLE
IntelliJ: Remove `\"` which doesn't work in Powershell.

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
@@ -62,7 +62,7 @@ public class BlazeQueryDirectoryToTargetProvider implements DirectoryToTargetPro
       targets.append(" - " + TargetExpression.allFromPackageRecursive(excluded).toString());
     }
     // exclude 'manual' targets, which shouldn't be built when expanding wildcard target patterns
-    return String.format("attr(\"tags\", \"^((?!manual).)*$\", %s)", targets);
+    return String.format("attr('tags', '^((?!manual).)*$', %s)", targets);
   }
 
   /**


### PR DESCRIPTION
It has been impossible to use Bazel Plugin for IntelliJ on Windows, since `\"` is not an escaped character in Powershell. Therefore, I don't think we have any Windows users (no idea what will happen if they use Cmd).

Could you please have a look?

PiperOrigin-RevId: 400322089

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

